### PR TITLE
#44 - refactoring user registration

### DIFF
--- a/server/src/i18n/error-messages.ts
+++ b/server/src/i18n/error-messages.ts
@@ -1,5 +1,6 @@
 export const ERROR_MESSAGES: any = {
   "auth.not.authorized": "The user has unsufficient permission to access the requested resource",
+  "auth.only.email.allowed": "The Registration is only with an email address allowed.",
   "auth.password.missmatch": "Passwords do not match",
   "auth.token.error": "Token error",
   "auth.token.expired": "Token expired",

--- a/server/src/logic/handler/routes/auth.handler.ts
+++ b/server/src/logic/handler/routes/auth.handler.ts
@@ -11,24 +11,15 @@ export class AuthHandler {
 
   public login = (req: SocoboRequest, res: Response): void => {
     this._getExtractedRequestBodyResult(req, "login(..)")
-      .then((result: ExtractRequestBodyResult) => {
-        return this._authService.login(result.isEmailLogin, result.usernameOrEmail, result.password);
-      })
-      .then((loginResult: LoginResponse) => {
-        res.status(200).json(loginResult);
-      })
+      .then((result: ExtractRequestBodyResult) => this._authService.login(result))
+      .then((loginResult: LoginResponse) => res.status(200).json(loginResult))
       .catch((error: any) => res.status(error.statusCode).json(error.forResponse()));
   }
 
   public register = (req: SocoboRequest, res: Response): void => {
     this._getExtractedRequestBodyResult(req, "register(..)")
-      .then((result: ExtractRequestBodyResult) => {
-        return this._authService.register(result.isEmailLogin, result.usernameOrEmail,
-                                          result.password, result.role);
-      })
-      .then((user: SocoboUser) => {
-        res.status(200).json(user);
-      })
+      .then((result: ExtractRequestBodyResult) => this._authService.register(result))
+      .then((user: SocoboUser) => res.status(200).json(user))
       .catch((error: any) => res.status(error.statusCode).json(error.forResponse()));
   }
 

--- a/server/src/logic/services/auth.service.ts
+++ b/server/src/logic/services/auth.service.ts
@@ -2,7 +2,7 @@ import * as jwt from "jsonwebtoken";
 import { IDatabase } from "pg-promise";
 import { Config } from "./../../config";
 import {
-  ApiError, ComparePwResult, DbError, ERRORS,
+  ApiError, ComparePwResult, DbError, ERRORS, ExtractRequestBodyResult,
   LoginResponse, ProviderType, Role, SocoboUser
 } from "./../../models/index";
 import { DbExtensions } from "./../../models/index";
@@ -15,16 +15,16 @@ export class AuthService {
     private _cryptoUtils: CryptoUtils
   ) {}
 
-  public login (isEmailLogin: boolean, usernameOrEmail: string, password: string): Promise<LoginResponse> {
+  public login (erbr: ExtractRequestBodyResult): Promise<LoginResponse> {
     return new Promise((resolve, reject) => {
-      this._getUserFromDatabase(isEmailLogin, usernameOrEmail)
+      this._getUserFromDatabase(erbr.isEmailLogin, erbr.usernameOrEmail)
         .then((user: SocoboUser) => this._validateUser(user))
-        .then((foundUser: SocoboUser) => this._cryptoUtils.comparePasswords(password, foundUser))
+        .then((foundUser: SocoboUser) => this._cryptoUtils.comparePasswords(erbr.password, foundUser))
         .then((cr: ComparePwResult) => this._validateComparePasswords(cr.isPasswordMatch, cr.user))
         .then((user: SocoboUser) => resolve(this._createLoginResult(user)))
         .catch((error: any) => {
           if (error.code === ERRORS.USER_NOT_FOUND.code) {
-            const e = new DbError(ERRORS.AUTH_NOT_REGISTERED.withArgs(usernameOrEmail))
+            const e = new DbError(ERRORS.AUTH_NOT_REGISTERED.withArgs(erbr.usernameOrEmail))
               .addSource(AuthService.name)
               .addSourceMethod("login(..)")
               .addCause(error)
@@ -38,15 +38,14 @@ export class AuthService {
     });
   }
 
-  public register (isEmailLogin: boolean, usernameOrEmail: string,
-                   password: string, role: Role): Promise<SocoboUser> {
+  public register (erbr: ExtractRequestBodyResult): Promise<SocoboUser> {
     return new Promise((resolve, reject) => {
-      this._getUserFromDatabase(isEmailLogin, usernameOrEmail)
+      this._getUserFromDatabase(erbr.isEmailLogin, erbr.usernameOrEmail)
         .then((user: SocoboUser) => this._checkIfUserIsAlreadyRegistered(user))
         .catch((errorOne: any) => {
           if (errorOne.code === ERRORS.USER_NOT_FOUND.code) {
-            this._cryptoUtils.hashPassword(password)
-              .then((hashedPassword: string) => this._createNewUser(hashedPassword, usernameOrEmail, role))
+            this._cryptoUtils.hashPassword(erbr.password)
+              .then((hashedPassword: string) => this._createNewUser(hashedPassword, erbr.usernameOrEmail, erbr.role))
               .then((createdUser: SocoboUser) => resolve(this._returnSavedUser(createdUser)))
               .catch((errorTwo: any) => reject(errorTwo));
           } else {

--- a/server/src/logic/services/auth.service.ts
+++ b/server/src/logic/services/auth.service.ts
@@ -61,7 +61,7 @@ export class AuthService {
     if (isEmailLogin) {
       return this._db.users.getUserByEmail(usernameOrEmail);
     }
-    
+
     if (!onlyEmailRegistration) {
       return this._db.users.getUserByUsername(usernameOrEmail);
     }

--- a/server/src/models/errors/errors.ts
+++ b/server/src/models/errors/errors.ts
@@ -86,7 +86,7 @@ export class ERRORS {
     "20011",
     "auth.only.email.allowed",
     400
-  )
+  );
   public static USER_NOT_AUTHORIZED = new ErrorType(
     "10011",
     "auth.not.authorized",

--- a/server/src/models/errors/errors.ts
+++ b/server/src/models/errors/errors.ts
@@ -82,6 +82,11 @@ export class ERRORS {
     "auth.user.not.registerd",
     401
   );
+  public static AUTH_ONLY_EMAIL_ALLOWED = new ErrorType(
+    "20011",
+    "auth.only.email.allowed",
+    400
+  )
   public static USER_NOT_AUTHORIZED = new ErrorType(
     "10011",
     "auth.not.authorized",


### PR DESCRIPTION
i haven't found any good solution for "register new user inside promise.then() not promise.catch()".
i think this not really needed!?